### PR TITLE
Don't follow redirects when validating package names with PyPI

### DIFF
--- a/emporium/emporium/validators.py
+++ b/emporium/emporium/validators.py
@@ -3,6 +3,9 @@ from django.core.exceptions import ValidationError
 
 
 def validate_package_name_exists(name):
-    resp = requests.get("https://pypi.org/pypi/%s/json" % name)
+    resp = requests.get(
+        "https://pypi.org/pypi/%s/json" % name,
+        allow_redirects=False,  # PyPI will correct case with redirects, and argh
+    )
     if resp.status_code != 200:
         raise ValidationError("%(name)s not found on PyPI", params={"name": name})


### PR DESCRIPTION
Because PyPI will correct `django` to `Django`