### PR TITLE
Only show setup.py to authenticated users

### DIFF
--- a/emporium/emporium/templates/emporium/package_detail.html
+++ b/emporium/emporium/templates/emporium/package_detail.html
@@ -47,8 +47,10 @@
 							{% endfor %}
 						</ul>
 
-						<h4><code>setup.py</code></h4>
-						<pre>{{ pv.setuppy|linebreaksbr }}</pre>
+						{% if user.is_authenticated %}
+							<h4><code>setup.py</code></h4>
+							<pre>{{ pv.setuppy|linebreaksbr }}</pre>
+						{% endif %}
 
 						{% if user.is_authenticated %}
 							{% if pv.fetched %}


### PR DESCRIPTION
I want to cut down on hosting liability and not just blindly publicly
show them