### PR TITLE
Drop bmemcached binary option

### DIFF
--- a/emporium/emporium/settings.py
+++ b/emporium/emporium/settings.py
@@ -38,7 +38,6 @@ if "MEMCACHEDCLOUD_SERVERS" in os.environ:
             "OPTIONS": {
                 "username": os.environ.get("MEMCACHEDCLOUD_USERNAME"),
                 "password": os.environ.get("MEMCACHEDCLOUD_PASSWORD"),
-                "binary": True,
             },
         }
     }


### PR DESCRIPTION
No *you’re* blindly committing fixes from your phone...

0.3.0 of the memcached lib passes options directly to memcached and binary isn’t a valid option and sadness ensues and I don’t have integration tests to catch this...