### PR TITLE
Use default Dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,3 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-  open-pull-requests-limit: 99


### PR DESCRIPTION
High limit meant that there was constant churn as many other PRs would get updated and tested each time one got merged

Default is 5!