### PR TITLE
Drop the Python matrix from GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,17 +12,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: [3.8]
-
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.8
     - name: docker-compose build to warm things up
       run: |
         docker-compose build


### PR DESCRIPTION
We only ever care about one Python version at a time - the one we're
deploying - no need for a matrix

(Plus it makes the "required tests" config in GitHub more work - because
the version is part of the name - it's "build(3.8)" not "build" - so
that needs to be updated too with every Python upgrade)
