### PR TITLE
Update README to indicate Emporium is offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Emporium
 
+**Emporium served its purpose, but has been far superseded by excellent tools like libraries.io and deps.dev, and is now offline**
+
 > Good morning, Sir. Welcome to the National Cheese Emporium!
 
 https://blog.doismellburning.co.uk/mapping-python-dependencies-with-emporium/


### PR DESCRIPTION
Added note about Emporium being offline and superseded by other tools.